### PR TITLE
[Feature] SH-191 스터디 수락, 거절 기능 구현

### DIFF
--- a/src/main/java/kr/co/studyhubinu/studyhubserver/userstudy/controller/UserStudyController.java
+++ b/src/main/java/kr/co/studyhubinu/studyhubserver/userstudy/controller/UserStudyController.java
@@ -1,7 +1,8 @@
 package kr.co.studyhubinu.studyhubserver.userstudy.controller;
 
 
-import kr.co.studyhubinu.studyhubserver.userstudy.dto.request.UserStudyRequestDto;
+import kr.co.studyhubinu.studyhubserver.userstudy.dto.request.ApproveUserStudyRequestDto;
+import kr.co.studyhubinu.studyhubserver.userstudy.dto.request.RefuseUserStudyRequestDto;
 import kr.co.studyhubinu.studyhubserver.userstudy.service.UserStudyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,13 +19,14 @@ public class UserStudyController {
     private final UserStudyService userStudyService;
 
     @PostMapping("/approve")
-    public ResponseEntity<HttpStatus> approveUser(UserStudyRequestDto userStudyRequestDto) {
-        userStudyService.approve(userStudyRequestDto.getUserId(), userStudyRequestDto.getPostId());
+    public ResponseEntity<HttpStatus> approveUser(ApproveUserStudyRequestDto approveUserStudyRequestDto) {
+        userStudyService.approve(approveUserStudyRequestDto.getUserId(), approveUserStudyRequestDto.getPostId());
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
-//    @PostMapping("/refuse")
-//    public ResponseEntity<HttpStatus> deleteUser() {
-//
-//    }
+    @PostMapping("/refuse")
+    public ResponseEntity<HttpStatus> refuseUser(RefuseUserStudyRequestDto refuseUserStudyRequestDto) {
+        userStudyService.refuse(refuseUserStudyRequestDto.getUserId(), refuseUserStudyRequestDto.getStudyId());
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/src/main/java/kr/co/studyhubinu/studyhubserver/userstudy/controller/UserStudyController.java
+++ b/src/main/java/kr/co/studyhubinu/studyhubserver/userstudy/controller/UserStudyController.java
@@ -1,0 +1,30 @@
+package kr.co.studyhubinu.studyhubserver.userstudy.controller;
+
+
+import kr.co.studyhubinu.studyhubserver.userstudy.dto.request.UserStudyRequestDto;
+import kr.co.studyhubinu.studyhubserver.userstudy.service.UserStudyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/study")
+public class UserStudyController {
+
+    private final UserStudyService userStudyService;
+
+    @PostMapping("/approve")
+    public ResponseEntity<HttpStatus> approveUser(UserStudyRequestDto userStudyRequestDto) {
+        userStudyService.approve(userStudyRequestDto.getUserId(), userStudyRequestDto.getPostId());
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+//    @PostMapping("/refuse")
+//    public ResponseEntity<HttpStatus> deleteUser() {
+//
+//    }
+}

--- a/src/main/java/kr/co/studyhubinu/studyhubserver/userstudy/domain/UserStudyEntity.java
+++ b/src/main/java/kr/co/studyhubinu/studyhubserver/userstudy/domain/UserStudyEntity.java
@@ -20,6 +20,8 @@ public class UserStudyEntity {
     @Column(name = "user_post_id")
     private Long id;
 
+    private boolean approve;
+
     @ManyToOne
     @JoinColumn(name = "post_id")
     private StudyEntity study;
@@ -29,7 +31,8 @@ public class UserStudyEntity {
     private UserEntity user;
 
     @Builder
-    public UserStudyEntity(StudyEntity study, UserEntity user) {
+    public UserStudyEntity(boolean approve, StudyEntity study, UserEntity user) {
+        this.approve = approve;
         this.study = study;
         this.user = user;
     }

--- a/src/main/java/kr/co/studyhubinu/studyhubserver/userstudy/dto/request/ApproveUserStudyRequestDto.java
+++ b/src/main/java/kr/co/studyhubinu/studyhubserver/userstudy/dto/request/ApproveUserStudyRequestDto.java
@@ -3,7 +3,7 @@ package kr.co.studyhubinu.studyhubserver.userstudy.dto.request;
 import lombok.Getter;
 
 @Getter
-public class UserStudyRequestDto {
+public class ApproveUserStudyRequestDto {
 
     private Long userId;
     private Long postId;

--- a/src/main/java/kr/co/studyhubinu/studyhubserver/userstudy/dto/request/RefuseUserStudyRequestDto.java
+++ b/src/main/java/kr/co/studyhubinu/studyhubserver/userstudy/dto/request/RefuseUserStudyRequestDto.java
@@ -1,0 +1,11 @@
+package kr.co.studyhubinu.studyhubserver.userstudy.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class RefuseUserStudyRequestDto {
+
+    private Long userId;
+
+    private Long studyId;
+}

--- a/src/main/java/kr/co/studyhubinu/studyhubserver/userstudy/dto/request/UserStudyRequestDto.java
+++ b/src/main/java/kr/co/studyhubinu/studyhubserver/userstudy/dto/request/UserStudyRequestDto.java
@@ -1,0 +1,11 @@
+package kr.co.studyhubinu.studyhubserver.userstudy.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class UserStudyRequestDto {
+
+    private Long userId;
+    private Long postId;
+
+}

--- a/src/main/java/kr/co/studyhubinu/studyhubserver/userstudy/service/UserStudyService.java
+++ b/src/main/java/kr/co/studyhubinu/studyhubserver/userstudy/service/UserStudyService.java
@@ -21,7 +21,14 @@ public class UserStudyService {
     public void approve(Long userId, Long studyId) {
         UserEntity user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         StudyEntity study = studyRepository.findById(studyId).orElseThrow();
-        UserStudyEntity userStudyEntity = new UserStudyEntity(study, user);
+        UserStudyEntity userStudyEntity = new UserStudyEntity(true, study, user);
+        userStudyRepository.save(userStudyEntity);
+    }
+
+    public void refuse(Long userId, Long studyId) {
+        UserEntity user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        StudyEntity study = studyRepository.findById(studyId).orElseThrow();
+        UserStudyEntity userStudyEntity = new UserStudyEntity(false, study, user);
         userStudyRepository.save(userStudyEntity);
     }
 }

--- a/src/main/java/kr/co/studyhubinu/studyhubserver/userstudy/service/UserStudyService.java
+++ b/src/main/java/kr/co/studyhubinu/studyhubserver/userstudy/service/UserStudyService.java
@@ -1,0 +1,27 @@
+package kr.co.studyhubinu.studyhubserver.userstudy.service;
+
+import kr.co.studyhubinu.studyhubserver.exception.user.UserNotFoundException;
+import kr.co.studyhubinu.studyhubserver.study.StudyRepository;
+import kr.co.studyhubinu.studyhubserver.study.domain.StudyEntity;
+import kr.co.studyhubinu.studyhubserver.user.domain.UserEntity;
+import kr.co.studyhubinu.studyhubserver.user.repository.UserRepository;
+import kr.co.studyhubinu.studyhubserver.userstudy.domain.UserStudyEntity;
+import kr.co.studyhubinu.studyhubserver.userstudy.repository.UserStudyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class UserStudyService {
+
+    private final UserRepository userRepository;
+    private final StudyRepository studyRepository;
+    private final UserStudyRepository userStudyRepository;
+
+    public void approve(Long userId, Long studyId) {
+        UserEntity user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        StudyEntity study = studyRepository.findById(studyId).orElseThrow();
+        UserStudyEntity userStudyEntity = new UserStudyEntity(study, user);
+        userStudyRepository.save(userStudyEntity);
+    }
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -78,6 +78,7 @@ CREATE TABLE bookmark
 
 CREATE TABLE user_study (
       user_post_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+      approve boolean,
       post_id BIGINT,
       user_id BIGINT,
       FOREIGN KEY (post_id) REFERENCES study(study_id),


### PR DESCRIPTION
## 🛠 구현 사항

### 문제 : 
스터디 수락을 구현할 때 원래 있던 UserStudyEntity 에 저장하게되면 거절이 불가능해진다.

### 해결 : 
UserStudyEntity 필드에 boolean approve 생성해 true == 수락, false == 거절로 상태 저장
