### PR TITLE
[Fix] : deleteUser 메소드 Transactional 어노테이션 추가

### DIFF
--- a/src/main/java/kr/co/studyhubinu/studyhubserver/user/service/UserService.java
+++ b/src/main/java/kr/co/studyhubinu/studyhubserver/user/service/UserService.java
@@ -42,7 +42,8 @@ public class UserService {
         UserEntity user = userRepository.findById(info.getUserId()).orElseThrow(UserNotFoundException::new);
         user.update(info);
     }
-  
+
+    @Transactional
     public void deleteUser(Long userId) {
         UserEntity user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         userDeleter.deleteUserRelatedData(user);


### PR DESCRIPTION
## 🛠 구현 사항


deleteUser 메소드 Transactional 어노테이션이 없어 회원 탈퇴가 안되는 문제를 해결했습니다.
