### PR TITLE
[Test] : 게시글과_유저의_식별자로_댓글을_조회한다

### DIFF
--- a/src/test/java/kr/co/studyhubinu/studyhubserver/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/kr/co/studyhubinu/studyhubserver/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,51 @@
+package kr.co.studyhubinu.studyhubserver.comment.repository;
+
+import kr.co.studyhubinu.studyhubserver.comment.domain.CommentEntity;
+import kr.co.studyhubinu.studyhubserver.comment.dto.response.CommentResponse;
+import kr.co.studyhubinu.studyhubserver.support.fixture.CommentEntityFixture;
+import kr.co.studyhubinu.studyhubserver.support.repository.RepositoryTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@RepositoryTest
+@ActiveProfiles("dev")
+public class CommentRepositoryTest {
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Test
+    void 게시글과_유저의_식별자로_댓글을_조회한다() {
+        // given
+        Long userId = 1L;
+        Long postId = 3L;
+        CommentEntity comment1 = CommentEntityFixture.COMMENT_1.commentEntity_생성(1L, userId, postId);
+        CommentEntity comment2 = CommentEntityFixture.COMMENT_2.commentEntity_생성(2L, userId, postId);
+        commentRepository.save(comment1);
+        commentRepository.save(comment2);
+        // when
+        Pageable pageable = PageRequest.of(0, 10); // 예제에서는 페이지 처리를 사용하고 있으므로 Pageable을 설정
+        Slice<CommentResponse> comments = commentRepository.findSliceByPostIdWithUserId(1L, userId, pageable);
+        // then
+        assertThat(comments.getContent()).hasSize(2); // 두 개의 댓글을 기대한다고 가정합니다.
+
+        CommentResponse commentResponse1 = comments.getContent().get(1);
+        CommentResponse commentResponse2 = comments.getContent().get(0);
+
+        System.out.println(commentResponse1.getContent());
+
+        assertEquals(comment1.getId(), commentResponse1.getCommentId());
+        assertEquals(comment1.getContent(), commentResponse1.getContent());
+
+        assertEquals(comment2.getId(), commentResponse2.getCommentId());
+        assertEquals(comment2.getContent(), commentResponse2.getContent());
+    }
+
+}

--- a/src/test/java/kr/co/studyhubinu/studyhubserver/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/kr/co/studyhubinu/studyhubserver/comment/repository/CommentRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @RepositoryTest
@@ -30,9 +31,11 @@ public class CommentRepositoryTest {
         CommentEntity comment2 = CommentEntityFixture.COMMENT_2.commentEntity_생성(2L, userId, postId);
         commentRepository.save(comment1);
         commentRepository.save(comment2);
+
         // when
         Pageable pageable = PageRequest.of(0, 10); // 예제에서는 페이지 처리를 사용하고 있으므로 Pageable을 설정
         Slice<CommentResponse> comments = commentRepository.findSliceByPostIdWithUserId(1L, userId, pageable);
+
         // then
         assertThat(comments.getContent()).hasSize(2); // 두 개의 댓글을 기대한다고 가정합니다.
 
@@ -41,11 +44,12 @@ public class CommentRepositoryTest {
 
         System.out.println(commentResponse1.getContent());
 
-        assertEquals(comment1.getId(), commentResponse1.getCommentId());
-        assertEquals(comment1.getContent(), commentResponse1.getContent());
-
-        assertEquals(comment2.getId(), commentResponse2.getCommentId());
-        assertEquals(comment2.getContent(), commentResponse2.getContent());
+        assertAll(
+                () -> assertEquals(comment1.getId(), commentResponse1.getCommentId()),
+                () -> assertEquals(comment1.getContent(), commentResponse1.getContent()),
+                () -> assertEquals(comment2.getId(), commentResponse2.getCommentId()),
+                () -> assertEquals(comment2.getContent(), commentResponse2.getContent())
+        );
     }
 
 }

--- a/src/test/java/kr/co/studyhubinu/studyhubserver/support/fixture/CommentEntityFixture.java
+++ b/src/test/java/kr/co/studyhubinu/studyhubserver/support/fixture/CommentEntityFixture.java
@@ -1,0 +1,24 @@
+package kr.co.studyhubinu.studyhubserver.support.fixture;
+
+import kr.co.studyhubinu.studyhubserver.comment.domain.CommentEntity;
+
+public enum CommentEntityFixture {
+
+    COMMENT_1("신입생도 참가할 수 있나요?"),
+    COMMENT_2("4학년 막학기도 참여할 수 있나요?");
+
+    private final String content;
+
+    CommentEntityFixture(String content) {
+        this.content = content;
+    }
+
+    public CommentEntity commentEntity_생성(Long commentId, Long userId, Long postId) {
+        return CommentEntity.builder()
+                .id(commentId)
+                .postId(postId)
+                .userId(userId)
+                .content(this.content)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📋 이슈 번호

🛠 구현 사항
- 게시글과_유저의_식별자로_댓글을_조회한다

## 📚 기타
