### PR TITLE
Fix/SH-270 comment

### DIFF
--- a/src/main/java/kr/co/studyhubinu/studyhubserver/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/kr/co/studyhubinu/studyhubserver/comment/repository/CommentRepositoryCustom.java
@@ -2,8 +2,9 @@ package kr.co.studyhubinu.studyhubserver.comment.repository;
 
 import kr.co.studyhubinu.studyhubserver.comment.dto.response.CommentResponse;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
+
+import java.util.List;
 
 public interface CommentRepositoryCustom {
-    Slice<CommentResponse> findSliceByPostIdWithUserId(Long postId, Long userId, Pageable pageable);
+    List<CommentResponse> findSliceByPostIdWithUserId(Long postId, Long userId, Pageable pageable);
 }

--- a/src/main/java/kr/co/studyhubinu/studyhubserver/comment/repository/CommentRepositoryImpl.java
+++ b/src/main/java/kr/co/studyhubinu/studyhubserver/comment/repository/CommentRepositoryImpl.java
@@ -1,18 +1,13 @@
 package kr.co.studyhubinu.studyhubserver.comment.repository;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import kr.co.studyhubinu.studyhubserver.comment.domain.QCommentEntity;
 import kr.co.studyhubinu.studyhubserver.comment.dto.response.CommentResponse;
-import kr.co.studyhubinu.studyhubserver.studypost.domain.QStudyPostEntity;
-import kr.co.studyhubinu.studyhubserver.user.domain.QUserEntity;
 import kr.co.studyhubinu.studyhubserver.user.dto.data.UserData;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -23,45 +18,40 @@ import static kr.co.studyhubinu.studyhubserver.user.domain.QUserEntity.userEntit
 
 @Repository
 @RequiredArgsConstructor
-public class CommentRepositoryImpl implements CommentRepositoryCustom{
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-
     @Override
-    public Slice<CommentResponse> findSliceByPostIdWithUserId(Long postId, Long userId, Pageable pageable) {
-        QStudyPostEntity post = studyPostEntity;
-        QCommentEntity comment = commentEntity;
-        QUserEntity user = userEntity;
-
-        JPAQuery<CommentResponse> data = jpaQueryFactory
+    public List<CommentResponse> findSliceByPostIdWithUserId(Long postId, Long userId, Pageable pageable) {
+        return jpaQueryFactory
                 .select(Projections.constructor(CommentResponse.class,
-                        comment.id,
-                        comment.content,
-                        comment.createdDate,
-                        userId != null ? Expressions.booleanTemplate("{0} = {1}", comment.userId, userId) : Expressions.constant(false),
+                        commentEntity.id,
+                        commentEntity.content,
+                        commentEntity.createdDate,
+                        loginPredicate(userId),
                         Projections.constructor(
                                 UserData.class,
-                                user.id,
-                                user.major,
-                                user.nickname,
-                                user.imageUrl
+                                userEntity.id,
+                                userEntity.major,
+                                userEntity.nickname,
+                                userEntity.imageUrl
                         )
 
                 ))
-                .from(comment)
-                .leftJoin(user).on(comment.userId.eq(user.id))
-                .orderBy(comment.createdDate.desc())
+                .from(commentEntity)
+                .leftJoin(userEntity).on(commentEntity.userId.eq(userEntity.id))
+                .where(commentEntity.postId.eq(postId))
+                .orderBy(commentEntity.createdDate.desc())
                 .offset(pageable.getOffset())
-                .limit(pageable.getPageSize() + 1);
-        return toSlice(pageable, data.fetch());
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
     }
 
-    public static <T> Slice<T> toSlice(final Pageable pageable, final List<T> items) {
-        if (items.size() > pageable.getPageSize()) {
-            items.remove(items.size() - 1);
-            return new SliceImpl<>(items, pageable, true);
+    private BooleanExpression loginPredicate(Long userId) {
+        if (userId != null) {
+            return Expressions.booleanTemplate("{0} = {1}", commentEntity.userId, userId);
         }
-        return new SliceImpl<>(items, pageable, false);
+        return Expressions.asBoolean(Expressions.constant(false));
     }
 }

--- a/src/main/java/kr/co/studyhubinu/studyhubserver/comment/service/CommentService.java
+++ b/src/main/java/kr/co/studyhubinu/studyhubserver/comment/service/CommentService.java
@@ -6,6 +6,7 @@ import kr.co.studyhubinu.studyhubserver.comment.dto.request.CreateCommentRequest
 import kr.co.studyhubinu.studyhubserver.comment.dto.request.UpdateCommentRequest;
 import kr.co.studyhubinu.studyhubserver.comment.dto.response.CommentResponse;
 import kr.co.studyhubinu.studyhubserver.comment.repository.CommentRepository;
+import kr.co.studyhubinu.studyhubserver.common.dto.Converter;
 import kr.co.studyhubinu.studyhubserver.exception.comment.CommentNotFoundException;
 import kr.co.studyhubinu.studyhubserver.exception.study.PostNotFoundException;
 import kr.co.studyhubinu.studyhubserver.exception.user.UserNotFoundException;
@@ -59,7 +60,7 @@ public class CommentService {
         final Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdDate"));
         validateStudyPostExist(postId);
         validateUserExist(userId);
-        return commentRepository.findSliceByPostIdWithUserId(postId, userId, pageable);
+        return Converter.toSlice(pageable, commentRepository.findSliceByPostIdWithUserId(postId, userId, pageable));
     }
 
     private void validateUserExist(Long userId) {

--- a/src/test/java/kr/co/studyhubinu/studyhubserver/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/kr/co/studyhubinu/studyhubserver/comment/repository/CommentRepositoryTest.java
@@ -11,6 +11,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,24 +24,23 @@ class CommentRepositoryTest {
     private CommentRepository commentRepository;
 
     @Test
-    void 게시글과_유저의_식별자로_댓글을_최신순으로_조회한다() throws InterruptedException {
+    void 게시글과_유저의_식별자로_댓글을_최신순으로_조회한다() {
         // given
         Long userId = 1L;
         Long postId = 3L;
         CommentEntity comment1 = CommentEntityFixture.COMMENT_1.commentEntity_생성(userId, postId);
         CommentEntity comment2 = CommentEntityFixture.COMMENT_2.commentEntity_생성(userId, postId);
         commentRepository.save(comment1);
-        Thread.sleep(1000 * 2);
         commentRepository.save(comment2);
 
         // when
         Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdDate"));
-        Slice<CommentResponse> comments = commentRepository.findSliceByPostIdWithUserId(1L, userId, pageable);
+        List<CommentResponse> comments = commentRepository.findSliceByPostIdWithUserId(3L, userId, pageable);
 
         // then
-        assertThat(comments.getContent()).hasSize(2);
-        CommentResponse commentResponse1 = comments.getContent().get(1);
-        CommentResponse commentResponse2 = comments.getContent().get(0);
+        assertThat(comments.size()).isEqualTo(2);
+        CommentResponse commentResponse1 = comments.get(1);
+        CommentResponse commentResponse2 = comments.get(0);
 
         assertAll(
                 () -> assertEquals(comment1.getId(), commentResponse1.getCommentId()),

--- a/src/test/java/kr/co/studyhubinu/studyhubserver/studypost/service/StudyPostServiceTest.java
+++ b/src/test/java/kr/co/studyhubinu/studyhubserver/studypost/service/StudyPostServiceTest.java
@@ -52,8 +52,8 @@ class StudyPostServiceTest {
         StudyEntity studyEntity = StudyEntity.builder().id(1L).build();
         StudyPostEntityFixture fixture = StudyPostEntityFixture.SQLD;
         CreatePostRequest postRequest = CreatePostRequest.builder().
-                studyStartDate(LocalDate.of(2024, 1, 3)).
-                studyEndDate(LocalDate.of(2024, 10, 5)).
+                studyStartDate(LocalDate.of(2025, 1, 3)).
+                studyEndDate(LocalDate.of(2025, 10, 5)).
                 build();
 
         when(userRepository.findById(anyLong())).thenReturn(userEntity);
@@ -109,8 +109,8 @@ class StudyPostServiceTest {
         UpdateStudyPostInfo updateStudyPostInfo = UpdateStudyPostInfo.builder().
                 userId(1L).
                 postId(1L).
-                studyStartDate(LocalDate.of(2024, 1, 3)).
-                studyEndDate(LocalDate.of(2024, 10, 5)).
+                studyStartDate(LocalDate.of(2025, 1, 3)).
+                studyEndDate(LocalDate.of(2025, 10, 5)).
                 build();
 
         when(userRepository.findById(anyLong())).thenReturn(userEntity);


### PR DESCRIPTION
## 🛠 구현 사항

- 댓글 조회시 모든 게시글에서 같은 댓글이 조회되는 문제를 해결했습니다.
- 기존 쿼리문을 개선했습니다.


``` java
@Override
public List<CommentResponse> findSliceByPostIdWithUserId(Long postId, Long userId, Pageable pageable) {
    return jpaQueryFactory
            .select(Projections.constructor(CommentResponse.class,
                    commentEntity.id,
                    commentEntity.content,
                    commentEntity.createdDate,
                    loginPredicate(userId),
                    Projections.constructor(
                            UserData.class,
                            userEntity.id,
                            userEntity.major,
                            userEntity.nickname,
                            userEntity.imageUrl
                    )
  
            ))
            .from(commentEntity)
            .leftJoin(userEntity).on(commentEntity.userId.eq(userEntity.id))
            .where(commentEntity.postId.eq(postId))
            .orderBy(commentEntity.createdDate.desc())
            .offset(pageable.getOffset())
            .limit(pageable.getPageSize() + 1)
            .fetch();
}

private BooleanExpression loginPredicate(Long userId) {
    if (userId != null) {
        return Expressions.booleanTemplate("{0} = {1}", commentEntity.userId, userId);
    }
    return Expressions.asBoolean(Expressions.constant(false));
}
```