### PR TITLE
Feat/sh 287 post

### DIFF
--- a/src/main/java/kr/co/studyhubinu/studyhubserver/study/domain/StudyEntity.java
+++ b/src/main/java/kr/co/studyhubinu/studyhubserver/study/domain/StudyEntity.java
@@ -1,17 +1,16 @@
 package kr.co.studyhubinu.studyhubserver.study.domain;
 
-import kr.co.studyhubinu.studyhubserver.apply.domain.ApplyEntity;
+import kr.co.studyhubinu.studyhubserver.common.domain.BaseTimeEntity;
 import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDate;
-import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "study")
-public class StudyEntity {
+public class StudyEntity extends BaseTimeEntity {
 
     @Id
     @Column(name = "study_id")

--- a/src/main/java/kr/co/studyhubinu/studyhubserver/studypost/dto/data/PostDataByUserId.java
+++ b/src/main/java/kr/co/studyhubinu/studyhubserver/studypost/dto/data/PostDataByUserId.java
@@ -8,20 +8,22 @@ import lombok.Getter;
 @Getter
 public class PostDataByUserId {
 
-    private Long postId;
-    private MajorType major;
-    private String title;
-    private String content;
-    private Integer remainingSeat;
-    private boolean close;
+    private final Long postId;
+    private final MajorType major;
+    private final String title;
+    private final String content;
+    private final Integer remainingSeat;
+    private final boolean close;
+    private final Long studyId;
 
     @Builder
-    public PostDataByUserId(Long postId, MajorType major, String title, String content, Integer remainingSeat, boolean close) {
+    public PostDataByUserId(Long postId, MajorType major, String title, String content, Integer remainingSeat, boolean close, Long studyId) {
         this.postId = postId;
         this.major = major;
         this.title = title;
         this.content = content;
         this.remainingSeat = remainingSeat;
         this.close = close;
+        this.studyId = studyId;
     }
 }

--- a/src/main/java/kr/co/studyhubinu/studyhubserver/studypost/repository/StudyPostRepositoryImpl.java
+++ b/src/main/java/kr/co/studyhubinu/studyhubserver/studypost/repository/StudyPostRepositoryImpl.java
@@ -90,7 +90,8 @@ public class StudyPostRepositoryImpl implements StudyPostRepositoryCustom {
                                 post.title,
                                 post.content,
                                 post.remainingSeat,
-                                post.close
+                                post.close,
+                                post.studyId
                         )
                 )
                 .from(post)


### PR DESCRIPTION
## 🛠 구현 사항
### 참여자 버튼을 클릭했을 때 해당 study에 맞는 apply 데이터를 찾지 못하는 문제 해결

![image](https://github.com/study-hub-inu/study-hub-server/assets/97587573/eb4ec687-6b03-4ede-96c9-d310aeef7752)


내가 작성한 글을 조회할 때 게시글과 연결된 study 데이터의 식별자를 반환하도록 변경했습니다.